### PR TITLE
fix: header isMenuOpen and schema company id to uuid

### DIFF
--- a/client/src/components/Header/Header.module.css
+++ b/client/src/components/Header/Header.module.css
@@ -82,7 +82,6 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 100;
   display: flex;
   height: 100%;
 }

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -68,8 +68,8 @@ export const Header = () => {
           <div />
         </div>
       </div>
-      <div className={styles.menu}>
-        {isMenuOpen && (
+      {isMenuOpen && (
+        <div className={styles.menu}>
           <div className={styles.dropdown}>
             <Link href="#" className={styles.menuItem} onClick={() => setIsMenuOpen(false)}>
               ビジョン
@@ -96,8 +96,8 @@ export const Header = () => {
               </Link>
             )}
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </>
   );
 };

--- a/server/commonTypesWithClient/models.ts
+++ b/server/commonTypesWithClient/models.ts
@@ -20,7 +20,7 @@ export type TaskModel = z.infer<typeof taskParser>;
 
 export const employeeCompaniesParser = z.object({
   id: z.number(),
-  companyId: z.number(),
+  companyId: z.string(),
   roleId: z.number(),
   companyName: z.string().optional(),
 });
@@ -30,7 +30,7 @@ export type EmployeeCompaniesModel = z.infer<typeof employeeCompaniesParser>;
 export const tipParser = z.object({
   id: z.number(),
   employeeId: z.string(),
-  companyId: z.number(),
+  companyId: z.string(),
   amount: z.number(),
   createdAt: z.number(),
 });

--- a/server/prisma/migrations/20231128092340_/migration.sql
+++ b/server/prisma/migrations/20231128092340_/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - The primary key for the `Company` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "CompanyTip" DROP CONSTRAINT "CompanyTip_companyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "EmployeeCompany" DROP CONSTRAINT "EmployeeCompany_companyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Tip" DROP CONSTRAINT "Tip_companyId_fkey";
+
+-- AlterTable
+ALTER TABLE "Company" DROP CONSTRAINT "Company_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "Company_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "Company_id_seq";
+
+-- AlterTable
+ALTER TABLE "CompanyTip" ALTER COLUMN "companyId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "EmployeeCompany" ALTER COLUMN "companyId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "Tip" ALTER COLUMN "companyId" SET DATA TYPE TEXT;
+
+-- AddForeignKey
+ALTER TABLE "EmployeeCompany" ADD CONSTRAINT "EmployeeCompany_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tip" ADD CONSTRAINT "Tip_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CompanyTip" ADD CONSTRAINT "CompanyTip_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -36,7 +36,7 @@ model EmployeeProfile {
 }
 
 model Company {
-  id              Int               @id @default(autoincrement())
+  id              String               @id @default(uuid())
   name            String
   address         String
   description     String
@@ -50,7 +50,7 @@ model EmployeeCompany {
   employee   Employee @relation(fields: [employeeId], references: [firebaseUid], onDelete: Cascade)
   employeeId String
   company    Company  @relation(fields: [companyId], references: [id])
-  companyId  Int
+  companyId  String
   roleId     Int
   role       Role     @relation(fields: [roleId], references: [id])
 
@@ -68,14 +68,14 @@ model Tip {
   employee   Employee @relation(fields: [employeeId], references: [firebaseUid])
   employeeId String
   company    Company  @relation(fields: [companyId], references: [id])
-  companyId  Int
+  companyId  String
   amount     Int
   createdAt  DateTime @default(now())
 }
 
 model CompanyTip {
   id        Int      @id @default(autoincrement())
-  companyId Int
+  companyId String
   amount    Int
   createdAt DateTime @default(now())
   company   Company  @relation(fields: [companyId], references: [id])


### PR DESCRIPTION
## なぜ
Headerのmenuの部分がisMenuOpenになる前から表示されて、他のコンポーネントの上に透明に重なってクリックできなかったので、それを修正。

## やったこと
CompanyのidをURLに使うためuuidに変更。それに伴って、numberからstringに変更。